### PR TITLE
20210320 pr ied detonating on death

### DIFF
--- a/addons/core/functions/fnc_createIED.sqf
+++ b/addons/core/functions/fnc_createIED.sqf
@@ -68,12 +68,6 @@ _ied addEventHandler ["Hit", {
 	params ["_unit", "_source", "_damage", "_instigator"];
     _medDamage = random [1.5, 5, 10];
     _minDamage = random [0.001, 0.3, 1.5];
-    systemChat format ["%1", _medDamage];
-    systemChat format ["%1", _minDamage];
-    systemChat format ["%1", _source];
-    systemChat format ["%1", _damage];
-    systemChat format ["%1", _instigator];
-    systemChat format ["%1", _instigator];
     if (_damage > _medDamage ) then {
         _unit setDamage 1;
     } else {

--- a/addons/core/functions/fnc_createIED.sqf
+++ b/addons/core/functions/fnc_createIED.sqf
@@ -63,6 +63,31 @@ _fnc_addExtTrigger = {
 [_ied, _fnc_addExtTrigger, [_ied]] call EFUNC(network,createNetworkNode);
 [_ied, FUNC(detonateIED)] call EFUNC(network,assignNetworkReciever);
 
+// handling manual destruction of the IED, detonation should be instant
+_ied addEventHandler ["Hit", {
+	params ["_unit", "_source", "_damage", "_instigator"];
+    _medDamage = random [1.5, 5, 10];
+    _minDamage = random [0.001, 0.3, 1.5];
+    systemChat format ["%1", _medDamage];
+    systemChat format ["%1", _minDamage];
+    systemChat format ["%1", _source];
+    systemChat format ["%1", _damage];
+    systemChat format ["%1", _instigator];
+    systemChat format ["%1", _instigator];
+    if (_damage > _medDamage ) then {
+        _unit setDamage 1;
+    } else {
+        if(_medDamage < 4 && _damage > _minDamage ) then {
+            _unit setDamage 1;
+        } else {
+        _unit setDamage 0;
+        }
+    };
+}];
+_ied addEventHandler ["Killed", {
+	params ["_unit", "_killer", "_instigator", "_useEffects"];
+        [_unit] call rid_core_fnc_detonateIED;
+}];
 //Attach ACE actions to IED:
 [_ied] remoteExecCall [QFUNC(addIEDActions), 0, true];
 _ied;

--- a/addons/core/functions/fnc_createIED.sqf
+++ b/addons/core/functions/fnc_createIED.sqf
@@ -65,7 +65,7 @@ _fnc_addExtTrigger = {
 
 // handling manual destruction of the IED, detonation should be instant
 _ied addEventHandler ["Hit", {
-	params ["_unit", "_source", "_damage", "_instigator"];
+    params ["_unit", "_source", "_damage", "_instigator"];
     _medDamage = random [1.5, 5, 10];
     _minDamage = random [0.001, 0.3, 1.5];
     if (_damage > _medDamage ) then {
@@ -79,7 +79,7 @@ _ied addEventHandler ["Hit", {
     };
 }];
 _ied addEventHandler ["Killed", {
-	params ["_unit", "_killer", "_instigator", "_useEffects"];
+    params ["_unit", "_killer", "_instigator", "_useEffects"];
         [_unit] call rid_core_fnc_detonateIED;
 }];
 //Attach ACE actions to IED:


### PR DESCRIPTION
- Hit event handler, if damage is high enough it will kill the object, else will prevent ied from dying
- Killed event handler to call explosion function


**When merged this pull request will:**
- Add event handlers to handle players trying to destroy the IED without defusing it

Logic for the hit event handler; Adds two randomized checks for damage, a high threshold, which will allow for explosions, or high powered rifles to detonate on impact (For reference the CUP Barret 50 does 10 damage per hit, 7.62 does 0.16 per hit, 5.56 does 0.016 per hit), but has the normal be around 5 so other high powered cartridges also have a high chance of detonating. 
Second check is if the first check is low (volatile), then checks for again against a lower number.
If neither checks are met then the IED is fully healed so repeated shots rely on the checks to detonate.
The idea is that an awry shot from a standard rifle will not cause it to go off, but enough might, while also providing suitable alternatives to removing the threat, rather than only having to defuse it for the threat to be removed