### PR TITLE
Eden - Fix tripwire tool CTD

### DIFF
--- a/addons/eden/functions/fnc_toolsTripwireModule.sqf
+++ b/addons/eden/functions/fnc_toolsTripwireModule.sqf
@@ -14,7 +14,12 @@
  *
  * Public: [No]
  */
-(flatten (get3DENSelected "")) params [["_entity0", objNull, [objNull]], ["_entity1", objNull, [objNull]]];
+private _correctArguments = (flatten (get3DENSelected "")) params [["_entity0", objNull, [objNull]], ["_entity1", objNull, [objNull]]];
+
+//2 Objects need to be selected
+if !(_correctArguments) exitWith {
+    [localize "STR_RID_Eden_SelectTwoEntities", 1] call BIS_fnc_3DENNotification;
+};
 
 ["RID Create Tripwire"] collect3DENHistory {
     private _modulePosition = [[_entity0, _entity1]] call FUNC(calculateObjectsCenter);

--- a/addons/eden/stringtable.xml
+++ b/addons/eden/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="RID">
+    <Package name="Eden">
+        <Key ID="STR_RID_Eden_SelectTwoEntities">
+            <English>Selected two entities for tripwire creation.</English>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
ISSUE:

The tripwire tool would CTD if only one object was selected.

FIX:

Halt the tripwire creation if we don't have proper arguments.
